### PR TITLE
日付を選択して、占い結果を取得するまでを仮組み

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,26 @@
+<script setup lang="ts">
+const {
+  year,
+  month,
+  day,
+  min,
+  max,
+  targetDate,
+  changeDate,
+} = useDate()
+</script>
+
 <template>
   <div>
-    <NuxtWelcome />
+    <input type="date" :min="min" :max="max" :value="targetDate" @change="changeDate">
+    <pre>
+      {{ targetDate }}
+      <hr />
+      {{ year }}
+      {{ month }}
+      {{ day }}
+    </pre>
+    <FortuneResult v-if="targetDate" :year="year" :month="month" :day="day" :key="`${year}-${month}-${day}`" />
+    <InitialGuide v-else />
   </div>
 </template>

--- a/components/FortuneResult.vue
+++ b/components/FortuneResult.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+const props = defineProps<{
+  year: string,
+  month: string,
+  day: string,
+}>()
+
+let url = new URL('/api/horoscope', location.href)
+url.searchParams.set('year', props.year)
+url.searchParams.set('month', props.month)
+url.searchParams.set('day', props.day)
+
+
+const { data, pending, error } = await useAsyncData(
+  url.href,
+  () => $fetch(url.href)
+)
+</script>
+
+<template>
+  <div>
+    <p v-if="pending">Loading...</p>
+    <p v-else-if="error">Error...</p>
+    <pre v-else>
+      {{ data }}
+    </pre>
+  </div>
+</template>

--- a/components/InitialGuide.vue
+++ b/components/InitialGuide.vue
@@ -1,0 +1,3 @@
+<template>
+    <p>日付を選択してください。</p>
+</template>

--- a/composables/useDate.ts
+++ b/composables/useDate.ts
@@ -1,0 +1,35 @@
+export const useDate = () => {
+    const year = ref("")
+    const month = ref("")
+    const day = ref("")
+    const targetDate = ref("")
+  
+    const formatDate = (date: Date): string => {
+      const year = String(date.getFullYear())
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const day = String(date.getDate()).padStart(2, '0')
+      return `${year}-${month}-${day}`
+    }
+  
+    const min = formatDate(new Date())
+    const max = (() => {
+      const maxDate = new Date()
+      maxDate.setDate(maxDate.getDate() + 10)
+      return formatDate(maxDate)
+    })()
+  
+    const changeDate = (event: Event) => {
+      const newDate = (event.target as HTMLInputElement).value as string;
+      targetDate.value = newDate;
+      [year.value, month.value, day.value] = newDate.split('-');
+    }
+    return {
+      year,
+      month,
+      day,
+      min,
+      max,
+      targetDate,
+      changeDate,
+    }
+  }

--- a/server/api/horoscope.ts
+++ b/server/api/horoscope.ts
@@ -1,0 +1,11 @@
+export default defineEventHandler((event) => {
+    const { year, month, day } = getQuery(event)
+    try {
+      new Date(`${year}/${month}/${day}`)
+    } catch(e) {
+      return createError({
+        status: 400,
+      })
+    }
+    return $fetch(`http://api.jugemkey.jp/api/horoscope/free/${year}/${month}/${day}`)
+  })


### PR DESCRIPTION
- CORS制約の為、占い結果はサーバーAPIを経由して取得
- 日付の変更にリアクティブに対応するコンポーザブルを作成
- 年月日のPropsで占い結果を表示するコンポーネントを作成
- 日付未選択時の、初期表示用のコンポーネントを作成
- 日付の選択・変更で占い結果をリアクティブに表示