### PR TITLE
Vue Datepickerの採用

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-const { targetDate, changeDate } = useDate()
+const { targetDate } = useDate()
 </script>
 
 <template>
-  <AppHeader @update="changeDate" />
+  <AppHeader  />
   <main class="main-contents">
     <FortuneResult v-if="targetDate" :targetDate="targetDate" :key="targetDate" />
     <InitialGuide v-else />

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,14 +1,3 @@
-<script setup lang="ts">
-import { getToday, get10DaysLater } from "@/utils/date"
-const emits = defineEmits<{
-  update: [event: Event]
-}>()
-
-const min = getToday()
-const max = get10DaysLater()
-const onChange = (event: Event) => emits('update', event)
-</script>
-
 <template>
   <header class="header">
     <div class="header-container">
@@ -22,15 +11,7 @@ const onChange = (event: Event) => emits('update', event)
       </a>
 
       <div class="date-container">
-        <p class="date-description">日付を選択して下さい</p>
-        <input
-          type="date"
-          class="date-picker"
-          pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}"
-          :min="min"
-          :max="max"
-          @change="onChange"
-        />
+        <DatePicker />
       </div>
     </div>
   </header>
@@ -68,28 +49,11 @@ const onChange = (event: Event) => emits('update', event)
 }
 
 .date-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: stretch;
-}
-
-.date-description {
-  color: white;
-  font-size: 14px;
-  margin-bottom: 5px;
-}
-
-.date-picker {
-  background-color: white;
-  border: solid 2px var(--sub-color);
-  display: inline-block;
-  font-size: 16px;
-  padding: 3px;
   width: 100%;
-}
 
-.date-picker::-webkit-calendar-picker-indicator {
-  padding: 5px 0 0;
+  @include tab {
+    width: 240px;
+  };
 }
 </style>
 ~/utils/date

--- a/components/DatePicker.vue
+++ b/components/DatePicker.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import VueDatePicker from '@vuepic/vue-datepicker'
+import '@vuepic/vue-datepicker/dist/main.css'
+import { useDate } from "@/composables/useDate"
+import { formatDate } from "@/utils/date"
+
+const { targetDate, changeDate } = useDate()
+</script>
+
+<template>
+  <VueDatePicker
+    :enable-time-picker="false"
+    model-type="yyyy-MM-dd"
+    placeholder="日付を選択して下さい"
+    auto-apply
+    :format="formatDate"
+    :model-value="targetDate"
+    @update:model-value="changeDate"
+  />
+</template>

--- a/composables/useDate.ts
+++ b/composables/useDate.ts
@@ -1,11 +1,11 @@
 export const useDate = () => {
-    const targetDate = ref("")
+  const targetDate = useState('target-date', () => "")
 
-    const changeDate = (event: Event) => {
-      targetDate.value = (event.target as HTMLInputElement).value as string;
-    }
-    return {
-      targetDate,
-      changeDate,
-    }
+  const changeDate = (newDate: string) => {
+    targetDate.value = newDate;
   }
+  return {
+    targetDate: readonly(targetDate),
+    changeDate,
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,6 +2,9 @@
 export default defineNuxtConfig({
   devtools: { enabled: true },
   css: ['@/assets/css/main.scss'],
+  build: {
+    transpile: ['@vuepic/vue-datepicker']
+  },
   vite: {
     css: {
       preprocessorOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "name": "nuxt-app",
       "hasInstallScript": true,
+      "dependencies": {
+        "@vuepic/vue-datepicker": "^6.0.3"
+      },
       "devDependencies": {
         "@nuxt/devtools": "latest",
         "@testing-library/jest-dom": "^6.1.2",
@@ -495,7 +498,6 @@
       "version": "7.22.13",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.13.tgz",
       "integrity": "sha512-3l6+4YOvc9wx7VlCSw4yQfcBo01ECA8TicQfbnCPuCEpRQrf+gTUyGdxNw+pyTUyywp6JRD1w0YQs9TpBXYlkw==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -567,7 +569,6 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
       "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1535,8 +1536,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.19",
@@ -3495,7 +3495,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
       "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
-      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.21.3",
         "@vue/shared": "3.3.4",
@@ -3506,14 +3505,12 @@
     "node_modules/@vue/compiler-core/node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@vue/compiler-dom": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
       "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-core": "3.3.4",
         "@vue/shared": "3.3.4"
@@ -3523,7 +3520,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
       "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
-      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.15",
         "@vue/compiler-core": "3.3.4",
@@ -3540,14 +3536,12 @@
     "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
       "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-dom": "3.3.4",
         "@vue/shared": "3.3.4"
@@ -3563,7 +3557,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
       "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
-      "dev": true,
       "dependencies": {
         "@vue/shared": "3.3.4"
       }
@@ -3572,7 +3565,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
       "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.15",
         "@vue/compiler-core": "3.3.4",
@@ -3584,14 +3576,12 @@
     "node_modules/@vue/reactivity-transform/node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@vue/runtime-core": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
       "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
-      "dev": true,
       "dependencies": {
         "@vue/reactivity": "3.3.4",
         "@vue/shared": "3.3.4"
@@ -3601,7 +3591,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
       "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
-      "dev": true,
       "dependencies": {
         "@vue/runtime-core": "3.3.4",
         "@vue/shared": "3.3.4",
@@ -3612,7 +3601,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
       "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.3.4",
         "@vue/shared": "3.3.4"
@@ -3624,8 +3612,7 @@
     "node_modules/@vue/shared": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
-      "dev": true
+      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
     },
     "node_modules/@vue/test-utils": {
       "version": "2.4.1",
@@ -3644,6 +3631,21 @@
         "@vue/server-renderer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vuepic/vue-datepicker": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-6.0.3.tgz",
+      "integrity": "sha512-LxUZfxEsu6sSti/3pdkYO6NxwhF8mXSUhuINWEXhDHnfi0kyDgAIbJPJPf32WJLyoXYbuevOJbSYhFt8FCxhlA==",
+      "dependencies": {
+        "date-fns": "^2.30.0",
+        "date-fns-tz": "^1.3.7"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "vue": ">=3.2.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -5519,8 +5521,7 @@
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/cuint": {
       "version": "0.2.2",
@@ -5583,6 +5584,29 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
+      "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debug": {
@@ -8543,7 +8567,6 @@
       "version": "0.30.3",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
       "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -10247,8 +10270,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -10307,7 +10329,6 @@
       "version": "8.4.28",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
       "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10886,7 +10907,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
       "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11247,8 +11267,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
@@ -12038,7 +12057,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14028,7 +14046,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
       "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-dom": "3.3.4",
         "@vue/compiler-sfc": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "sass": "^1.66.1",
     "sass-loader": "^13.3.2",
     "vitest": "^0.34.3"
+  },
+  "dependencies": {
+    "@vuepic/vue-datepicker": "^6.0.3"
   }
 }

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,4 +1,4 @@
-const formatDate = (date: Date): string => {
+export const formatDate = (date: Date): string => {
   const year = String(date.getFullYear())
   const month = String(date.getMonth() + 1).padStart(2, '0')
   const day = String(date.getDate()).padStart(2, '0')


### PR DESCRIPTION
HTML標準搭載の`input type="date"`は、日付選択がカレンダーからの指定だけではなく、テキスト入力も可能で扱いずらかった。また、ブラウザによってUIや機能に差異が有るので使い勝手が悪かった。
そこを補うべく`Vue Datepicker`を採用し、コンポーネントを差し替えた。

また、それに伴いuseDateコンポーザブルをコンポーネント間でも共通して使える様に、useStateを使って書き換えた。

[Vue datepicker公式サイト](https://vue3datepicker.com/)