### PR TITLE
Lint / Test のアクションを改善

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: npm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+          cache: npm
 
       - name: Install packages
         run: npm ci

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
 
       - name: Install packages
         run: npm ci


### PR DESCRIPTION
actions/checkout@v2で使っているnodeが12で古いと警告が出ていた。

なので
- actions/checkout@v4 にアップデート
- actions/setup-node@v3を使ってNode.jsのバージョンを指定
- actions/setup-node@v3のキャッシュを指定してアクションを高速化